### PR TITLE
Use SASS variable defaults for font path to allow override

### DIFF
--- a/font/css/open-iconic-bootstrap.scss
+++ b/font/css/open-iconic-bootstrap.scss
@@ -1,7 +1,7 @@
 /* Bootstrap */
 
 /* Override Bootstrap default variable */
-//$icon-font-path: '../fonts/';
+$icon-font-path: '../fonts/' !default;
 
 @font-face {
   font-family: 'Icons';

--- a/font/css/open-iconic-foundation.scss
+++ b/font/css/open-iconic-foundation.scss
@@ -1,7 +1,7 @@
 /* Foundation */
 
 /* Font path variable */
-$icon-font-path: '../fonts/';
+$icon-font-path: '../fonts/' !default;
 
 @font-face {
   font-family: 'Icons';

--- a/font/css/open-iconic.scss
+++ b/font/css/open-iconic.scss
@@ -1,4 +1,4 @@
-$iconic-font-path: '../fonts/';
+$iconic-font-path: '../fonts/' !default;
 
 @font-face {
   font-family: 'Icons';


### PR DESCRIPTION
When installing through bower or a similar package system, copying the style sheets out and modifying them to customize the path seems backwards. Thus when using the style sheets directly from the bower_components directory one needs to be able to override the font path variable. For SASS this is very easy with the `!default` flag, which is how Foundation solves customization too.

This adds it for all the SASS style sheets, making it very easy to import them directly from the bower_components directory and override the font path by setting a variable before importing.
