### PR TITLE
Add 'main' entry point to package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+// Empty file. It exists so that this package has an entry point for require.resolve()

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-// Empty file. It exists so that this package has an entry point for require.resolve()

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.1",
   "keywords": ["icon", "iconic", "open-iconic", "svg", "sprite", "font", "png", "webp"],
   "homepage": "http://useiconic.com/open-iconic/",
-  "main": "index.js",
+  "main": "font/css/open-iconic.css",
   "author": {
     "name": "Iconic",
     "email": "yourfriends@useiconic.com",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.1.1",
   "keywords": ["icon", "iconic", "open-iconic", "svg", "sprite", "font", "png", "webp"],
   "homepage": "http://useiconic.com/open-iconic/",
+  "main": "index.js",
   "author": {
     "name": "Iconic",
     "email": "yourfriends@useiconic.com",


### PR DESCRIPTION
My build system in a package requires a method of discovering the location of a package dependency (in this case, the open-iconic package). Depending on how I use our package the location of this open-iconic package changes relative to the build script. The details of why this is are not really important but suffice to say that I need a way to locate the package within node_modules. 

There is already a handy function which does this called `require.resolve()` which is in nodejs but method uses the location of the entry point of a package (specified by the "main" property in package.json) as the path to return.  Without "main" being specified in package.json `require.resolve()` fails.  

This PR adds that entry point as the`font/css/open-iconic.css` file. In reality it doesn't matter if this entry point it the one chosen or not. I just need the entry point to be within the package so feel free to change it to suit your needs.

Thanks.